### PR TITLE
Align release flow with other repos (mise.development.toml, goreleaser fixes)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,8 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: darwin
+        goarch: arm
     flags:
       - -trimpath
       - -buildvcs=false

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -11,4 +11,4 @@ run = "goreleaser release --clean --config .goreleaser.yml"
 
 [tasks.release]
 description = "Alias for goreleaser_release"
-run = "mise run goreleaser_release"
+depends = ["goreleaser_release"]

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -1,0 +1,14 @@
+[tools]
+goreleaser = "2.13.3"
+
+[tasks.goreleaser_snapshot]
+description = "Build CLI artifacts via GoReleaser (snapshot)"
+run = "goreleaser release --snapshot --clean --config .goreleaser.yml"
+
+[tasks.goreleaser_release]
+description = "Publish GitHub Release via GoReleaser"
+run = "goreleaser release --clean --config .goreleaser.yml"
+
+[tasks.release]
+description = "Alias for goreleaser_release"
+run = "mise run goreleaser_release"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 go = "1.26.0"
-goreleaser = "2.13.3"
 
 [tasks.fix]
 description = "Auto-applies Golang fixes"
@@ -23,15 +22,3 @@ run = "node scripts/sync_versions.mjs"
 description = "Build the application binary"
 depends = ["fix"]
 run = "go build ./cmd/wework"
-
-[tasks.goreleaser_snapshot]
-description = "Build CLI artifacts via GoReleaser (snapshot)"
-run = "goreleaser release --snapshot --clean --config .goreleaser.yml"
-
-[tasks.goreleaser_release]
-description = "Publish GitHub Release via GoReleaser"
-run = "goreleaser release --clean --config .goreleaser.yml"
-
-[tasks.release]
-description = "Alias for goreleaser_release"
-run = "mise run goreleaser_release"


### PR DESCRIPTION
## Summary

- Move `goreleaser` tool + release tasks to `mise.development.toml` so they're only loaded with `MISE_ENV=development`
- Add `darwin/arm` to goreleaser ignore list (`darwin/armv7` has been unsupported since Go 1.15)